### PR TITLE
Add restrictions & safeguards for getting/setting NTP time

### DIFF
--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -716,11 +716,14 @@ void setCurrentTime(u64 time)
 
 void resetTimeNTP()
 {
-    curTime = 0;
-    origTime = 0;
-    Result ts = timeSetCurrentTime(TimeType_NetworkSystemClock, ntpGetTime());
-    if (R_FAILED(ts))
-        fatalThrow(ts);
+    time_t newTime = ntpGetTime();
+    // Do not set bad times that are likely server errors.
+    if (newTime >= 946706400) // New time has to be after 1/1/2000 0:00:00
+    {
+        Result ts = timeSetCurrentTime(TimeType_NetworkSystemClock, newTime);
+        if (R_FAILED(ts))
+            fatalThrow(ts);
+    }
 }
 
 void sendUsbResponse(USBResponse response)

--- a/sys-botbase/source/ntp.c
+++ b/sys-botbase/source/ntp.c
@@ -30,27 +30,39 @@ information. */
 #include <netinet/in.h>
 #include <switch.h>
 #include <sys/socket.h>
+#include <unistd.h>
 
 time_t ntpGetTime() {
     static const char* SERVER_NAME = "0.pool.ntp.org";
-    int sockfd = -1;
-    sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+
+    int sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sockfd <= 0)
+        return 0;
+
     struct hostent* server;
     server = gethostbyname(SERVER_NAME);
+    if (!server) {
+        close(sockfd);
+        return 0;
+    }
 
     struct sockaddr_in serv_addr;
     memset(&serv_addr, 0, sizeof(struct sockaddr_in));
     serv_addr.sin_family = AF_INET;
     memcpy((char*)&serv_addr.sin_addr.s_addr, (char*)server->h_addr_list[0], 4);
     serv_addr.sin_port = htons(123);
-    connect(sockfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr));
+    if (connect(sockfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) <= 0)
+        return 0;
 
     ntp_packet packet;
     memset(&packet, 0, sizeof(ntp_packet));
     packet.li_vn_mode = (0 << 6) | (4 << 3) | 3;              // LI 0 | Client version 4 | Mode 3
     packet.txTm_s = htonl(NTP_TIMESTAMP_DELTA + time(NULL));  // Current networktime on the console
-    send(sockfd, (char*)&packet, sizeof(ntp_packet), 0);
-    (size_t)(recv(sockfd, (char*)&packet, sizeof(ntp_packet), 0));
+    if (send(sockfd, (char*)&packet, sizeof(ntp_packet), 0) <= 0)
+        return 0;
+    if (recv(sockfd, (char*)&packet, sizeof(ntp_packet), 0) <= 0)
+        return 0;
+
     packet.txTm_s = ntohl(packet.txTm_s);
 
     return (time_t)(packet.txTm_s - NTP_TIMESTAMP_DELTA);

--- a/sys-botbase/source/ntp.c
+++ b/sys-botbase/source/ntp.c
@@ -36,10 +36,8 @@ time_t ntpGetTime() {
     static const char* SERVER_NAME = "0.pool.ntp.org";
 
     int sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-    if (sockfd <= 0) {
-        close(sockfd);
+    if (sockfd < 0)
         return 0;
-    }
 
     struct hostent* server;
     server = gethostbyname(SERVER_NAME);
@@ -51,9 +49,22 @@ time_t ntpGetTime() {
     struct sockaddr_in serv_addr;
     memset(&serv_addr, 0, sizeof(struct sockaddr_in));
     serv_addr.sin_family = AF_INET;
-    memcpy((char*)&serv_addr.sin_addr.s_addr, (char*)server->h_addr_list[0], 4);
+
+    // Validate server->h_addr_list[0] before using it
+    if (server->h_addr_list == NULL || server->h_addr_list[0] == NULL) {
+        close(sockfd);
+        return 0;
+    }
+
+    // Ensure the address length is sufficient
+    if (server->h_length < sizeof(serv_addr.sin_addr.s_addr)) {
+        close(sockfd);
+        return 0;
+    }
+
+    memcpy((char*)&serv_addr.sin_addr.s_addr, (char*)server->h_addr_list[0], sizeof(serv_addr.sin_addr.s_addr));
     serv_addr.sin_port = htons(123);
-    if (connect(sockfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) <= 0) {
+    if (connect(sockfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) < 0) {
         close(sockfd);
         return 0;
     }
@@ -62,16 +73,17 @@ time_t ntpGetTime() {
     memset(&packet, 0, sizeof(ntp_packet));
     packet.li_vn_mode = (0 << 6) | (4 << 3) | 3;              // LI 0 | Client version 4 | Mode 3
     packet.txTm_s = htonl(NTP_TIMESTAMP_DELTA + time(NULL));  // Current networktime on the console
-    if (send(sockfd, (char*)&packet, sizeof(ntp_packet), 0) <= 0) {
+
+    if (send(sockfd, (char*)&packet, sizeof(ntp_packet), 0) <= 0) { // Return value is bytes received
         close(sockfd);
         return 0;
     }
-    if (recv(sockfd, (char*)&packet, sizeof(ntp_packet), 0) <= 0) {
+    if (recv(sockfd, (char*)&packet, sizeof(ntp_packet), 0) <= 0) { // Return value is bytes received
         close(sockfd);
         return 0;
     }
 
     packet.txTm_s = ntohl(packet.txTm_s);
-
+    close(sockfd);
     return (time_t)(packet.txTm_s - NTP_TIMESTAMP_DELTA);
 }

--- a/sys-botbase/source/ntp.c
+++ b/sys-botbase/source/ntp.c
@@ -36,8 +36,10 @@ time_t ntpGetTime() {
     static const char* SERVER_NAME = "0.pool.ntp.org";
 
     int sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-    if (sockfd <= 0)
+    if (sockfd <= 0) {
+        close(sockfd);
         return 0;
+    }
 
     struct hostent* server;
     server = gethostbyname(SERVER_NAME);
@@ -51,17 +53,23 @@ time_t ntpGetTime() {
     serv_addr.sin_family = AF_INET;
     memcpy((char*)&serv_addr.sin_addr.s_addr, (char*)server->h_addr_list[0], 4);
     serv_addr.sin_port = htons(123);
-    if (connect(sockfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) <= 0)
+    if (connect(sockfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) <= 0) {
+        close(sockfd);
         return 0;
+    }
 
     ntp_packet packet;
     memset(&packet, 0, sizeof(ntp_packet));
     packet.li_vn_mode = (0 << 6) | (4 << 3) | 3;              // LI 0 | Client version 4 | Mode 3
     packet.txTm_s = htonl(NTP_TIMESTAMP_DELTA + time(NULL));  // Current networktime on the console
-    if (send(sockfd, (char*)&packet, sizeof(ntp_packet), 0) <= 0)
+    if (send(sockfd, (char*)&packet, sizeof(ntp_packet), 0) <= 0) {
+        close(sockfd);
         return 0;
-    if (recv(sockfd, (char*)&packet, sizeof(ntp_packet), 0) <= 0)
+    }
+    if (recv(sockfd, (char*)&packet, sizeof(ntp_packet), 0) <= 0) {
+        close(sockfd);
         return 0;
+    }
 
     packet.txTm_s = ntohl(packet.txTm_s);
 


### PR DESCRIPTION
Original code queries NTP server and sets the time regardless of the response. This causes issues when the NTP server is queried too often, as whatever erroneous response is set instead, locking the Switch date to 1999.

This is just a simple patch for now to only set the date when it's after 1/1/2000, which is the lowest bound on the Switch valid dates.